### PR TITLE
https://github.com/halkyonio/rhte_lab_2019/issues/33

### DIFF
--- a/scripts/lab_state_refresh.sh
+++ b/scripts/lab_state_refresh.sh
@@ -1,5 +1,6 @@
 tekton_project=tekton-pipelines
 operators_project=operators
+kubedb_project=kubedb
 
 
 updateOperators() {
@@ -15,6 +16,8 @@ scaleOperators() {
 
   oc scale --replicas=1 deployment tekton-pipelines-webhook -n $tekton_project --as=system:admin
   oc scale --replicas=1 deployment tekton-pipelines-controller -n $tekton_project --as=system:admin
+
+  oc scale --replicas=1 deployment kubedb-operator -n $kubedb_project --as=system:admin
 
 }
 


### PR DESCRIPTION
Latest blueprint now also has kubedb-operator deployment with replicas=0.
This pull request modifies the lab_state_refresh.sh script to set replicas=1 on this operator.